### PR TITLE
Add support for AAAA, SPF and SRV record types

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 var dns = require('dns');
 var net = require('net');
+var ip  = require('ipaddr.js');
 
 
 var axfrReqProloge = 
@@ -166,6 +167,29 @@ function parseResponse(response, result) {
                 len = response[offset+10];
                 entry.txt = response.toString('utf8', offset+11, offset+11+len);
                 break;
+
+            /* AAAA Record */
+            case 0x1c:
+                entry.type = 'AAAA';
+                var byteArr = new Uint8Array(response.slice(offset+10, offset+26));
+                entry.aaaa = ip.fromByteArray(byteArr).toString;
+                break;
+
+            /* SPF Record */
+            case 0x63:
+                entry.type = 'SPF';
+                len = response[offset+10];
+                entry.txt = response.toString('utf8', offset+11, offset+11+len);
+                break;
+
+            /* SRV Record */
+            case 0x21:
+                entry.type = 'SRV';
+                entry.priority = response.readUInt16BE(offset+10);
+                entry.weight   = response.readUInt16BE(offset+12);
+                entry.port     = response.readUInt16BE(offset+14);
+                entry.target   = decompressLabel(response, (offset+16)).nam
+
         }
 
         delete entry.len;

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "type": "git",
     "url": "https://github.com/jpenalbae/dns-axfr.git"
   },
- "files": [
+  "files": [
     "README.md",
     "LICENSE",
     "index.js",
@@ -30,5 +30,8 @@
   "bugs": {
     "url": "https://github.com/jpenalbae/dns-axfr/issues"
   },
-  "homepage": "https://github.com/jpenalbae/dns-axfr"
+  "homepage": "https://github.com/jpenalbae/dns-axfr",
+  "dependencies": {
+    "ipaddr.js": "^1.5.2"
+  }
 }


### PR DESCRIPTION
I needed support for the AAAA, SPF and SRV record types as I needed them for a small project. I used the ipaddr.js lib to ease the parsing/shortening of the v6 addresses - this adds a dependency to your otherwise standalone package. Please review the code and comment if anything needed.